### PR TITLE
generateJSON function to accept repetitions as a pointer

### DIFF
--- a/Fast HANSOLO generator.c
+++ b/Fast HANSOLO generator.c
@@ -17,7 +17,7 @@ void generateJSON(FILE* file, int* repetitions) {
 }
 
 int main() {
-    int repetitions = 10000;
+    int repetitions = 1000000000;
     FILE* file = fopen("HANSOLO.json", "w");
 
     if (file == NULL) {

--- a/Fast HANSOLO generator.c
+++ b/Fast HANSOLO generator.c
@@ -3,12 +3,12 @@
 const char* jsonData = "{\"data\":[";
 const char* hansoloData = "\"HANSOLO\"";
 
-void generateJSON(FILE* file, int repetitions) {
+void generateJSON(FILE* file, int* repetitions) {
     fprintf(file, "%s", jsonData);
 
-    for (int i = 0; i < repetitions; i++) {
+    for (int i = 0; i < *repetitions; i++) {
         fprintf(file, "%s", hansoloData);
-        if (i < repetitions - 1) {
+        if (i < *repetitions - 1) {
             fprintf(file, ",");
         }
     }
@@ -17,7 +17,7 @@ void generateJSON(FILE* file, int repetitions) {
 }
 
 int main() {
-    int repetitions = 1000000000;
+    int repetitions = 10000;
     FILE* file = fopen("HANSOLO.json", "w");
 
     if (file == NULL) {
@@ -25,7 +25,7 @@ int main() {
         return 1;
     }
 
-    generateJSON(file, repetitions);
+    generateJSON(file, &repetitions);
 
     fclose(file);
     printf("HANSOLO.json created successfully with %d repetitions.\n", repetitions);


### PR DESCRIPTION
Fixed sub-optimal all tests pass.

Bringing repetitions variable as a it's pointer to generateJSON will use fewer recources, because when function is executed it will create copy of the variable, but not anymore with this klinoff fix.

- nöfnöf